### PR TITLE
Feature/transaction meta

### DIFF
--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
@@ -50,6 +50,9 @@
           <span *ngSwitchCase="'send'" class="tx-type sent">
             <mat-icon fontSet="partIcon" fontIcon="part-send" color="warn"></mat-icon>
             <span class="name">Sent</span>
+            <span *ngIf="tx.type_output == 'anon'" class="name">(ANON)</span>
+            <span *ngIf="tx.type_output == 'standard'" class="name">(PUBLIC)</span>
+            <span *ngIf="tx.type_output == 'blind'" class="name">(BLIND)</span>
             <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
                       matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
           </span>
@@ -62,6 +65,9 @@
           <span *ngSwitchCase="'receive'" class="tx-type received">
             <mat-icon fontSet="partIcon" fontIcon="part-receive" color="primary"></mat-icon>
             <span class="name">Received</span>
+            <span *ngIf="tx.type_in == 'anon'" class="name">(ANON)</span>
+            <span *ngIf="tx.type_in == 'standard'" class="name">(PUBLIC)</span>
+            <span *ngIf="tx.type_in == 'blind'" class="name">(BLIND)</span>
             <mat-icon class="narration" *ngIf="tx.getNarration()" fontSet="partIcon" fontIcon="part-pen-1"
                       matTooltip="{{tx.getNarration()}}" matTooltipPosition="after"></mat-icon>
           </span>

--- a/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
+++ b/src/app/wallet/wallet/shared/transaction-table/transaction-table.component.html
@@ -67,7 +67,12 @@
           </span>
           <span *ngSwitchCase="'internal_transfer'" class="tx-type received">
             <mat-icon fontSet="partIcon" fontIcon="part-transfer" color="primary"></mat-icon>
-            <span class="name">Balance transfer</span>
+            <span *ngIf="tx.type_in == 'anon' && tx.type_output == 'standard' " class="name">ANON --> PUBLIC</span>
+            <span *ngIf="tx.type_in == 'standard' && tx.type_output == 'anon' " class="name">PUBLIC --> ANON</span>
+            <span *ngIf="tx.type_in == 'blind' && tx.type_output == 'standard' " class="name">BLIND --> PUBLIC</span>
+            <span *ngIf="tx.type_in == 'standard' && tx.type_output == 'blind' " class="name">PUBLIC --> BLIND</span>
+            <span *ngIf="tx.type_in == 'blind' && tx.type_output == 'anon' " class="name">BLIND --> ANON</span>
+            <span *ngIf="tx.type_in == 'anon' && tx.type_output == 'blind' " class="name">ANON --> BLIND</span>
           </span>
           <span *ngSwitchCase="'listing_fee'" class="tx-type listing-fee">
             <mat-icon fontSet="partIcon" fontIcon="part-bag-buy"></mat-icon>

--- a/src/app/wallet/wallet/shared/transaction.model.ts
+++ b/src/app/wallet/wallet/shared/transaction.model.ts
@@ -39,8 +39,8 @@ export class Transaction {
     blockindex: number;
     blocktime: number;
     confirmations: number;
-    type_in?: 'anon' | 'blind' | 'standard';
-    type_output?: 'anon' | 'blind' | 'standard';
+    type_in?: 'anon' | 'blind' | 'standard' = null;
+    type_output?: 'anon' | 'blind' | 'standard' = null;
 
   constructor(json: any) {
     /* transactions */
@@ -49,8 +49,10 @@ export class Transaction {
       this.address = json.outputs[0].address;
       this.stealth_address = json.outputs[0].stealth_address;
       this.label = json.outputs[0].label;
-      if(json.outputs[0].type){
+      if (json.outputs[0].type) {
         this.type_output = json.outputs[0].type;
+      } else {
+        this.type_output = 'standard';
       }
     }
     this.category = json.category;
@@ -74,6 +76,8 @@ export class Transaction {
     this.confirmations = json.confirmations;
     if (json.type_in) {
       this.type_in = json.type_in;
+    } else {
+      this.type_in = 'standard';
     }
 
 
@@ -145,7 +149,9 @@ export class Transaction {
       const add = function (a: any, b: any) { return a + (b.vout === 65535 ? 0 : b.amount); }
       return this.outputs.reduce(add, 0);
       */
-
+      if (this.type_in === 'standard') {
+        return this.amount;
+      }
 
       const blindStealthOutputCount = this.outputs.reduce(function (a: any, b: any) {
         return a + (b.vout !== 65535 ? (b.stealth_address !== undefined ? 1 : 0) : 0);

--- a/src/app/wallet/wallet/shared/transaction.model.ts
+++ b/src/app/wallet/wallet/shared/transaction.model.ts
@@ -39,6 +39,8 @@ export class Transaction {
     blockindex: number;
     blocktime: number;
     confirmations: number;
+    type_in?: 'anon' | 'blind' | 'standard';
+    type_output?: 'anon' | 'blind' | 'standard';
 
   constructor(json: any) {
     /* transactions */
@@ -47,6 +49,9 @@ export class Transaction {
       this.address = json.outputs[0].address;
       this.stealth_address = json.outputs[0].stealth_address;
       this.label = json.outputs[0].label;
+      if(json.outputs[0].type){
+        this.type_output = json.outputs[0].type;
+      }
     }
     this.category = json.category;
     this.amount = json.amount;
@@ -67,6 +72,11 @@ export class Transaction {
     this.blockindex = json.blockindex;
     this.blocktime = json.blocktime;
     this.confirmations = json.confirmations;
+    if (json.type_in) {
+      this.type_in = json.type_in;
+    }
+
+
   }
 
   public getAddress(): string {
@@ -74,6 +84,14 @@ export class Transaction {
       return this.address;
     }
     return this.stealth_address;
+  }
+
+  public getTypeIn(): string {
+    return this.type_in || '';
+  }
+
+  public getTypeOut(): string {
+    return this.type_output || '';
   }
 
   private getAddressType(): AddressType {
@@ -128,16 +146,16 @@ export class Transaction {
       return this.outputs.reduce(add, 0);
       */
 
-/*
+
       const blindStealthOutputCount = this.outputs.reduce(function (a: any, b: any) {
         return a + (b.vout !== 65535 ? (b.stealth_address !== undefined ? 1 : 0) : 0);
       }, 0);
 
       // blind -> blind (own)
-      if(blindStealthOutputCount === 1) {
+      if (blindStealthOutputCount === 1) {
         const add = function (a: any, b: any) { return a + (b.stealth_address !== undefined ? b.amount : 0); }
         return this.outputs.reduce(add, 0);
-      } */
+      }
 
       // only use fake output to determine internal transfer
       const fakeOutput = function (a: any, b: any) { return a - (b.vout === 65535 ? b.amount : 0); }


### PR DESCRIPTION
### Adds more descriptive data to transactions history.

Current behavious not show to users how converts are from, and also not shows where sent and where received.

Instead of Balance Transfers, show clearly workflow from anon to public
On Sent --> Shows from type
On Receive --> Shows from type transaction 
fix not displaying converting balances

New Behaviour as follows:
![image](https://user-images.githubusercontent.com/8621730/85630492-17b82280-b64a-11ea-8617-23ade7217732.png)

To Investigate:

Check if is better put on red all public transactions, public transactions should be highlighed as bad on the UI



