### PR TITLE
Fix shutdown window not show on MacOS

### DIFF
--- a/closewindow.js
+++ b/closewindow.js
@@ -34,8 +34,9 @@ exports.initCloseWindow = () => {
     height:    675,
     minHeight: 675,
     icon:      path.join(__dirname, 'resources/icon.png'),
-
-    frame: false,
+    
+    titleBarStyle: 'hidden',
+    frame: true,
     darkTheme: true,
 
     webPreferences: {


### PR DESCRIPTION
On MacOs using frame equal false not works, so insteand set titleBarStyle to hidden make it, and leave frame equal true