### PR TITLE
Feature/improve hot staking feedback

### DIFF
--- a/src/app/core-ui/main/status/status.component.ts
+++ b/src/app/core-ui/main/status/status.component.ts
@@ -52,14 +52,6 @@ export class StatusComponent implements OnInit, OnDestroy {
       .pipe(takeWhile(() => !this.destroyed))
       .subscribe(status => this.coldStakingStatus = status);
 
-    this._rpcState.observe('getstakinginfo', 'staking')
-      .pipe(takeWhile(() => !this.destroyed))
-      .subscribe(status => this.stakingStatus = status);
-
-    this._rpcState.observe('getstakinginfo', 'enable')
-      .pipe(takeWhile(() => !this.destroyed))
-      .subscribe(status => this.stakingEnable = status);
-
     /* Bug: If you remove this line, then the state of 'txcount' doesn't update in the Transaction.service */
     this._rpcState.observe('getwalletinfo', 'txcount')
     .pipe(takeWhile(() => !this.destroyed))
@@ -101,7 +93,7 @@ export class StatusComponent implements OnInit, OnDestroy {
   }
 
   getStakingStatus() {
-    return (this.stakingStatus && !this.isLocked()) ? 'active' : 'inactive';
+    return (!this.isLocked()) ? 'active' : 'inactive';
   }
 
   toggle() {

--- a/src/app/core-ui/main/status/status.component.ts
+++ b/src/app/core-ui/main/status/status.component.ts
@@ -20,8 +20,6 @@ export class StatusComponent implements OnInit, OnDestroy {
 
   peerListCount: number = 0;
   public coldStakingStatus: boolean;
-  public stakingStatus: boolean;
-  public stakingEnable: boolean;
   public encryptionStatus: string = 'Locked';
   private _sub: Subscription;
   private destroyed: boolean = false;
@@ -115,7 +113,7 @@ export class StatusComponent implements OnInit, OnDestroy {
         break;
     }
   }
-  isLocked(){
+  isLocked() {
     return [
       'Locked',
     ].includes(this.encryptionStatus);

--- a/src/app/wallet/overview/widgets/stake/stake.component.html
+++ b/src/app/wallet/overview/widgets/stake/stake.component.html
@@ -3,7 +3,7 @@
     <div class="subtitle">Staking</div>
   </header>
 
-  <mat-card *ngIf="_stake.stakingEnabled && _stake.isStaking && !isLocked()" class="staking-node active">
+  <mat-card *ngIf="_stake.stakingEnabled && !isLocked()" class="staking-node active">
     <button mat-raised-button color="primary" (click)="lockWallet()" matTooltip="Lock wallet disable staking">
       <img class="filter-white" src="assets/icons/SVG/monetization-on.svg"/>
     </button>
@@ -19,17 +19,7 @@
     <div class="subtitle">Unlock to start staking</div>
   </mat-card>
 
-  <mat-card *ngIf="_stake.stakingEnabled && !_stake.isStaking && !isLocked()" class="staking-node inactive">
-    <div class="title">Not Staking</div>
-    <div class="subtitle">You do not have any coins to stake or your coins are not mature yet</div>
-  </mat-card>
-
-  <p class="widget-help" *ngIf="_stake.stakingEnabled && !_stake.isStaking && !isLocked()">
-    If your account is not able to stake please wait for up to 255 confirmations on the blockchain for your coins to mature (become eligible to stake). Additionally only public balances can be used to stake. If the issue persists please try relaunching your wallet client.
-  </p>
-
-
-  <p class="widget-help" *ngIf="_stake.stakingEnabled && _stake.isStaking && !isLocked()">
+  <p class="widget-help" *ngIf="_stake.stakingEnabled && _stake.hotstake.amount > 0 && !isLocked()">
     {{_stake.hotstake.amount}} of your balance is now staking. Only your public account balance can be used for staking.
   </p>
 

--- a/src/app/wallet/overview/widgets/stake/stake.service.ts
+++ b/src/app/wallet/overview/widgets/stake/stake.service.ts
@@ -18,8 +18,6 @@ export class StakeService implements OnDestroy {
   };
 
   stakingEnabled: boolean = undefined;
-  isStaking: boolean = undefined;
-  stakingCause: string = '';
   public encryptionStatus: string = 'Locked';
 
   private progress: Amount = new Amount(0, 2);
@@ -46,10 +44,6 @@ export class StakeService implements OnDestroy {
       .pipe(takeWhile(() => !this.destroyed))
       .subscribe(status => this.stakingEnabled = status);
 
-    this._rpcState.observe('getstakinginfo', 'staking')
-      .pipe(takeWhile(() => !this.destroyed))
-      .subscribe(status => this.isStaking = status);
-
     this.update();
   }
 
@@ -69,18 +63,7 @@ export class StakeService implements OnDestroy {
       } else {
         this.stakingEnabled = false;
       }
-      if ('staking' in stakinginfo) {
-        const staking = stakinginfo['staking'];
-        this.isStaking = staking;
-      } else {
-        this.isStaking = false;
-      }
-      if ('cause' in stakinginfo) {
-        const stakingCause = stakinginfo['cause'];
-        this.stakingCause = stakingCause;
-      } else {
-        this.stakingCause = '';
-      }
+
       this.updateHotStakingInfo();
     }, error => this.log.er('couldn\'t get stakinginfo', error));
   }


### PR DESCRIPTION
Closes #44 

Improves hot staking feedback to user and remove unecessary information for user.

Now we not show to users that coins are still to being mature as it is confusing them, and show hot staking widget active when getstakinginfo returns enable=true.

