### PR TITLE
Feature/add new wallet prefixs

### DIFF
--- a/src/app/installer/create-wallet/create-wallet.component.html
+++ b/src/app/installer/create-wallet/create-wallet.component.html
@@ -129,6 +129,9 @@
             <p class="widget-help">
               Wallet name should contain only letters, numbers, spaces <code> </code>, dashes <code>-</code> and underscores <code>_</code>.
             </p>
+            <p class="legacy-section" *ngIf="!isCreate">
+              <mat-checkbox [(ngModel)]="isLegacy">Legacy Import: Check this box if you created your wallet and mnemonic phrase BEFORE July 1st, 2020 (Core: 0.19.1.5)</mat-checkbox>
+            </p>
           </mat-card>
         </div>
         <!-- .container-block -->
@@ -322,9 +325,7 @@
             <p class="widget-help">
               <strong>Friendly reminder:</strong> Don't forget that the Recovery Phrase (and Password) are very important for keeping your funds safe. Anyone with access to them has access to your coins. If you think your Recovery Phrase (and Password) might have been exposed, it would be better to create a new wallet instead and send your coins there.
             </p>
-            <p class="legacy-section" *ngIf="!isCreate">
-              <mat-checkbox [(ngModel)]="isLegacy">Legacy Import: Check this box if you created your wallet and mnemonic phrase BEFORE July 1st, 2020 (Core: 0.19.1.5)</mat-checkbox>
-            </p>
+    
           </div>
         </div><!-- .page-intro -->
 

--- a/src/app/installer/create-wallet/create-wallet.component.html
+++ b/src/app/installer/create-wallet/create-wallet.component.html
@@ -323,7 +323,7 @@
               <strong>Friendly reminder:</strong> Don't forget that the Recovery Phrase (and Password) are very important for keeping your funds safe. Anyone with access to them has access to your coins. If you think your Recovery Phrase (and Password) might have been exposed, it would be better to create a new wallet instead and send your coins there.
             </p>
             <p class="legacy-section" *ngIf="!isCreate">
-              <mat-checkbox [(ngModel)]="isLegacy">Check this box if you created your account mnemonic phrase BEFORE  July 1st, 2020 (Core: 0.19.1.5)</mat-checkbox>
+              <mat-checkbox [(ngModel)]="isLegacy">Legacy Import: Check this box if you created your wallet and mnemonic phrase BEFORE July 1st, 2020 (Core: 0.19.1.5)</mat-checkbox>
             </p>
           </div>
         </div><!-- .page-intro -->

--- a/src/app/installer/create-wallet/create-wallet.component.html
+++ b/src/app/installer/create-wallet/create-wallet.component.html
@@ -352,6 +352,9 @@
             <mat-icon fontSet="partIcon" fontIcon="{{passwordRestoreElem.show ? 'part-anon' : 'part-public'}}"></mat-icon>
             {{ passwordRestoreElem.show ? 'Hide' : 'Show' }} password
           </button>
+          <section class="legacy-section">
+            <mat-checkbox [(ngModel)]="isLegacy">Check this box if you created your account mnemonic phrase BEFORE 1 July 2020</mat-checkbox>
+          </section>
         </mat-card>
         <!-- .recovery-password -->
 

--- a/src/app/installer/create-wallet/create-wallet.component.html
+++ b/src/app/installer/create-wallet/create-wallet.component.html
@@ -322,6 +322,9 @@
             <p class="widget-help">
               <strong>Friendly reminder:</strong> Don't forget that the Recovery Phrase (and Password) are very important for keeping your funds safe. Anyone with access to them has access to your coins. If you think your Recovery Phrase (and Password) might have been exposed, it would be better to create a new wallet instead and send your coins there.
             </p>
+            <section class="legacy-section" *ngIf="!isCreate">
+              <mat-checkbox [(ngModel)]="isLegacy">Check this box if you created your account mnemonic phrase BEFORE  July 1st, 2020 (Core: 0.19.1.5)</mat-checkbox>
+            </section>
           </div>
         </div><!-- .page-intro -->
 
@@ -352,9 +355,6 @@
             <mat-icon fontSet="partIcon" fontIcon="{{passwordRestoreElem.show ? 'part-anon' : 'part-public'}}"></mat-icon>
             {{ passwordRestoreElem.show ? 'Hide' : 'Show' }} password
           </button>
-          <section class="legacy-section">
-            <mat-checkbox [(ngModel)]="isLegacy">Check this box if you created your account mnemonic phrase BEFORE 1 July 2020</mat-checkbox>
-          </section>
         </mat-card>
         <!-- .recovery-password -->
 

--- a/src/app/installer/create-wallet/create-wallet.component.html
+++ b/src/app/installer/create-wallet/create-wallet.component.html
@@ -322,9 +322,9 @@
             <p class="widget-help">
               <strong>Friendly reminder:</strong> Don't forget that the Recovery Phrase (and Password) are very important for keeping your funds safe. Anyone with access to them has access to your coins. If you think your Recovery Phrase (and Password) might have been exposed, it would be better to create a new wallet instead and send your coins there.
             </p>
-            <section class="legacy-section" *ngIf="!isCreate">
+            <p class="legacy-section" *ngIf="!isCreate">
               <mat-checkbox [(ngModel)]="isLegacy">Check this box if you created your account mnemonic phrase BEFORE  July 1st, 2020 (Core: 0.19.1.5)</mat-checkbox>
-            </section>
+            </p>
           </div>
         </div><!-- .page-intro -->
 

--- a/src/app/installer/create-wallet/create-wallet.component.ts
+++ b/src/app/installer/create-wallet/create-wallet.component.ts
@@ -155,7 +155,8 @@ export class CreateWalletComponent implements OnInit {
         break;
 
       case Steps.WALLET_NAME:
-        this._rpc.call('createwallet', [this.walletname]).subscribe(
+        const params = [this.walletname, false, false, '', false, this.isLegacy ? true : false];
+        this._rpc.call('createwallet', params).subscribe(
           wallet => {
             this.log.d('createwallet: ', wallet);
             this.errorString = '';

--- a/src/app/installer/create-wallet/create-wallet.component.ts
+++ b/src/app/installer/create-wallet/create-wallet.component.ts
@@ -68,6 +68,8 @@ export class CreateWalletComponent implements OnInit {
   encrypt: string = '';
   encryptVerify: string = '';
 
+  isLegacy: boolean = false;
+
   constructor(
     private _passphraseService: PassphraseService,
     private _rpc: RpcService,
@@ -431,7 +433,7 @@ export class CreateWalletComponent implements OnInit {
   }
 
   private importMnemoic(): void {
-    this._passphraseService.importMnemonic(this.words, this.password).subscribe(
+    this._passphraseService.importMnemonic(this.words, this.password, this.isLegacy).subscribe(
       () => {
         this.log.i('Mnemonic imported successfully');
         this.goToStep(Steps.COMPLETED);

--- a/src/app/installer/create-wallet/passphrase/passphrase.service.ts
+++ b/src/app/installer/create-wallet/passphrase/passphrase.service.ts
@@ -39,10 +39,11 @@ export class PassphraseService {
     return this.validWords.indexOf(word) !== -1;
   }
 
-  importMnemonic(words: string[], password: string) {
-    const params = [words.join(' '), password];
+  importMnemonic(words: string[], password: string, isLegacy: boolean = false) {
+    const params = [words.join(' '), password, false , 'Master Key', 'Default Account', '0', isLegacy];
     if (!password) {
-      params.pop();
+      // If no password we use default value
+      params[1] = '';
     }
     return this._rpc.call('extkeygenesisimport', params).pipe(
       tap(() => this.generateDefaultAddresses()),

--- a/src/app/installer/create-wallet/passphrase/passphrase.service.ts
+++ b/src/app/installer/create-wallet/passphrase/passphrase.service.ts
@@ -40,12 +40,15 @@ export class PassphraseService {
   }
 
   importMnemonic(words: string[], password: string, isLegacy: boolean = false) {
-    const params = [words.join(' '), password, false , 'Master Key', 'Default Account', 0, isLegacy];
+    const params = [words.join(' '), password];
+
     if (!password) {
-      // If no password we use default value
-      params[1] = '';
+      params.pop();
     }
-    return this._rpc.call('extkeygenesisimport', params).pipe(
+
+    const command = isLegacy ? 'extkeygenesisimportlegacy' : 'extkeygenesisimport';
+
+    return this._rpc.call(command, params).pipe(
       tap(() => this.generateDefaultAddresses()),
       tap(() => this.rescanBlockchain()));
   }

--- a/src/app/installer/create-wallet/passphrase/passphrase.service.ts
+++ b/src/app/installer/create-wallet/passphrase/passphrase.service.ts
@@ -40,7 +40,7 @@ export class PassphraseService {
   }
 
   importMnemonic(words: string[], password: string, isLegacy: boolean = false) {
-    const params = [words.join(' '), password, false , 'Master Key', 'Default Account', '0', isLegacy];
+    const params = [words.join(' '), password, false , 'Master Key', 'Default Account', 0, isLegacy];
     if (!password) {
       // If no password we use default value
       params[1] = '';


### PR DESCRIPTION
Add option to user restore wallet with legacy prefix's

We added a isLegacy flag, when checked it pass true to legacy to the 'extkeygenesisimport' rpc command, by default the wallet is passing all default commands displayed on rpc description. 

A checkbox was added on Restore wallet page, this checkbox is not visible when on the create stage.


![image](https://user-images.githubusercontent.com/8621730/86156084-c7264680-badb-11ea-9987-79953b45baa5.png)


