### PR TITLE
enable cold staking

### DIFF
--- a/src/app/core-ui/main/status/status.component.html
+++ b/src/app/core-ui/main/status/status.component.html
@@ -20,14 +20,14 @@
     <mat-icon class="icon" fontSet="partIcon" fontIcon="part-currency-dollar"></mat-icon>
   </span>
 
- <!-- 
+ 
    <span
     class="staking icon"
     matTooltip="Cold staking {{ getColdStakingStatus() }}"
     [ngClass]="getColdStakingStatus()"
     container="body">
       <mat-icon fontSet="partIcon" fontIcon="part-snowflake"></mat-icon>
-  </span> -->
+  </span> 
   
   <span
     class="console icon"

--- a/src/app/core-ui/main/status/status.component.html
+++ b/src/app/core-ui/main/status/status.component.html
@@ -13,7 +13,7 @@
   </span>
 
   <span
-    class="staking icon"
+    class="hot-staking icon"
     matTooltip="Staking {{ getStakingStatus() }}"
     [ngClass]="getStakingStatus()"
     container="body">

--- a/src/app/core-ui/main/status/status.component.scss
+++ b/src/app/core-ui/main/status/status.component.scss
@@ -13,12 +13,23 @@
   padding: 1px 0 1px 4px;
   // Encryption
   &.encryption {
+    padding: 0px;
     cursor: pointer;
+  }
+   // Staking icon
+   &.hot-staking {
+    padding-left: 0px;
+    font-size: 0.8em;
+    &.active {
+      color: $color-info;
+    }
+    &.inactive {
+      color: darken($bg-shadow, 15%);
+    }
   }
 
   // Staking icon
   &.staking {
-    padding: 0px;
     font-size: 0.8em;
     &.active {
       color: $color-info;

--- a/src/app/core-ui/main/status/status.component.ts
+++ b/src/app/core-ui/main/status/status.component.ts
@@ -91,7 +91,7 @@ export class StatusComponent implements OnInit, OnDestroy {
   }
 
   getStakingStatus() {
-    return (!this.isLocked()) ? 'active' : 'inactive';
+    return (!this.isLocked()) ? (this.coldStakingStatus ? 'inactive' : 'active') : 'inactive';
   }
 
   toggle() {

--- a/src/app/core/util/utils.ts
+++ b/src/app/core/util/utils.ts
@@ -108,6 +108,11 @@ export class Amount {
     return (this.amount) / 100000000;
   }
 
+  // Convert satoshi coins to original Ghost coins
+  public getGhostCoins() {
+    return (this.amount) / 100000000;
+  }
+
 }
 
 export class Fee {

--- a/src/app/wallet/overview/overview.component.html
+++ b/src/app/wallet/overview/overview.component.html
@@ -21,12 +21,8 @@
       <td><app-balance type="locked_balance" [inSidebar]="true"></app-balance></td>
     </tr>
     <tr>
-      <th matTooltip="Coins currently (locked in) staking" matTooltipPosition="left">Staking</th>
-      <td><app-balance type="staked_balance" [inSidebar]="true"></app-balance></td>
-    </tr>
-    <tr>
       <th matTooltip="Immature coins not able to spend" matTooltipPosition="left">Immature</th>
-      <td><app-balance type="" types="immature_balance,immature_anon_balance" [inSidebar]="true"></app-balance></td>
+      <td><app-balance type="" types="immature_balance,immature_anon_balance,staked_balance" [inSidebar]="true"></app-balance></td>
     </tr>
     <tr>
       <th matTooltip="Incoming unconfirmed coins" matTooltipPosition="left">Unconfirmed</th>

--- a/src/app/wallet/overview/overview.component.html
+++ b/src/app/wallet/overview/overview.component.html
@@ -104,9 +104,9 @@
         </div>
       </mat-card>
     </div><!-- .buy-orders -->
+    <app-coldstake></app-coldstake> 
     <app-stake></app-stake>
 <!-- Removed Cold Staking, Enable this component when needed -->
- <!--   <app-coldstake></app-coldstake> -->
     <app-stakinginfo></app-stakinginfo>
 
     <!-- TODO: uncomment when widget management is ready -->

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -3,7 +3,7 @@
     <div class="subtitle">Cold Staking</div>
   </header>
 
-  <mat-card *ngIf="_coldstake.coldStakingEnabled" class="staking-node inactive">
+  <mat-card *ngIf="_coldstake.coldStakingEnabled && !checkLockStatus()" class="staking-node inactive">
     <button mat-raised-button color="primary" (click)="openUnlockWalletModal()" matTooltip="Unlock wallet to enable cold staking">
       <mat-icon fontSet="partIcon" fontIcon="part-lock"></mat-icon>
     </button>

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -51,7 +51,7 @@
     </mat-progress-bar>
     <!-- TODO: component ? -->
     <p class="buttons">
-      <button mat-button class="small" color="primary" matTooltip="Fast-forward to 100%" (click)="zap()" *ngIf="_coldstake.coldStakingEnabled&& _coldstake.coldstakeProgress < 100">
+      <button mat-button class="small" color="primary" matTooltip="Fast-forward to 100%" (click)="zap()" *ngIf="_coldstake.coldStakingEnabled && _coldstake.coldstakeProgress < 100">
         Zap
       </button>
       <button mat-button class="small" color="warn" matTooltip="Disable Cold Staking" (click)="revert()">
@@ -88,7 +88,7 @@
       <button mat-button class="small" color="primary"
         matTooltip="Fast-forward to 100%"
         (click)="zap()"
-        *ngIf="_coldstake.coldStakingEnabled&& _coldstake.coldstakeProgress < 100">
+        *ngIf="_coldstake.coldStakingEnabled && _coldstake.coldstakeProgress < 100">
         Zap
         <!-- <span class="tag zap">{{ hotstaking.txs.length }}</span> -->
       </button>

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -88,7 +88,7 @@
       <button mat-button class="small" color="primary"
         matTooltip="Fast-forward to 100%"
         (click)="zap()"
-        *ngIf="_coldstake.hotstake.txs.length">
+        *ngIf="_coldstake.coldStakingEnabled&& _coldstake.coldstakeProgress < 100">
         Zap
         <!-- <span class="tag zap">{{ hotstaking.txs.length }}</span> -->
       </button>

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -59,7 +59,7 @@
       </button>
     </p>
   </mat-card>
-  <p class="widget-help" *ngIf="_coldstake.coldStakingEnabled">
+  <p class="widget-help" *ngIf="_coldstake.coldStakingEnabled && _coldstake.coldstakeProgress < 100">
     {{_coldstake.coldstakeProgress}}% of your balance is now cold staking.
     The activation process will continue only when your wallet is online and unlocked for staking.
   </p>

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.html
@@ -51,7 +51,7 @@
     </mat-progress-bar>
     <!-- TODO: component ? -->
     <p class="buttons">
-      <button mat-button class="small" color="primary" matTooltip="Fast-forward to 100%" (click)="zap()" *ngIf="_coldstake.hotstake.txs.length">
+      <button mat-button class="small" color="primary" matTooltip="Fast-forward to 100%" (click)="zap()" *ngIf="_coldstake.coldStakingEnabled&& _coldstake.coldstakeProgress < 100">
         Zap
       </button>
       <button mat-button class="small" color="warn" matTooltip="Disable Cold Staking" (click)="revert()">

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.ts
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material';
 import { Log } from 'ng2-logger';
 
@@ -13,7 +13,7 @@ import { RevertColdstakingComponent } from './revert-coldstaking/revert-coldstak
   templateUrl: './coldstake.component.html',
   styleUrls: ['./coldstake.component.scss']
 })
-export class ColdstakeComponent {
+export class ColdstakeComponent implements OnInit {
 
   private log: any = Log.create('coldstake.component');
 
@@ -25,6 +25,10 @@ export class ColdstakeComponent {
     private _modals: ModalsHelperService,
     public _coldstake: ColdstakeService
   ) { }
+
+  ngOnInit() {
+    this._coldstake.update()
+  }
 
   zap() {
     this._modals.unlock({}, (status) => this.openZapColdstakingModal());
@@ -49,9 +53,7 @@ export class ColdstakeComponent {
   openColdStakeModal(): void {
     this._modals.coldStake('cold');
   }
-  ngOnInit(){
-    this._coldstake.update()
-  }
+
   checkLockStatus(): boolean {
     return [
       'Unlocked',

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.component.ts
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.component.ts
@@ -49,7 +49,9 @@ export class ColdstakeComponent {
   openColdStakeModal(): void {
     this._modals.coldStake('cold');
   }
-
+  ngOnInit(){
+    this._coldstake.update()
+  }
   checkLockStatus(): boolean {
     return [
       'Unlocked',

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.service.ts
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.service.ts
@@ -36,7 +36,9 @@ export class ColdstakeService implements OnDestroy {
     this._rpcState.observe('getcoldstakinginfo', 'enabled')
       .pipe(takeWhile(() => !this.destroyed))
       .subscribe(status => this.coldStakingEnabled = status);
-
+    this._rpcState.observe('getcoldstakinginfo', 'percent_in_coldstakeable_script')
+      .pipe(takeWhile(() => !this.destroyed))
+      .subscribe(progress =>  this.progress = new Amount(progress, 2));
     this.update();
   }
 

--- a/src/app/wallet/overview/widgets/coldstake/coldstake.service.ts
+++ b/src/app/wallet/overview/widgets/coldstake/coldstake.service.ts
@@ -33,27 +33,6 @@ export class ColdstakeService implements OnDestroy {
     private _rpcState: RpcStateService
   ) {
 
-    this._rpcState.observe('getwalletinfo', 'encryptionstatus')
-      .pipe(takeWhile(() => !this.destroyed))
-      .subscribe(status => {
-        this.encryptionStatus = status;
-        this.update();
-      });
-
-    this._rpcState.observe('getwalletinfo', 'txcount')
-      .pipe(takeWhile(() => !this.destroyed))
-      .pipe(debounceTime(1000/*ms*/))
-      .subscribe(txcount => {
-        this.update();
-      });
-
-    this._rpcState.observe('getblockchaininfo', 'blocks')
-      .pipe(takeWhile(() => !this.destroyed))
-      .pipe(debounceTime(10 * 1000/*ms*/))
-      .subscribe(status => {
-        this.update();
-      });
-
     this._rpcState.observe('getcoldstakinginfo', 'enabled')
       .pipe(takeWhile(() => !this.destroyed))
       .subscribe(status => this.coldStakingEnabled = status);
@@ -62,6 +41,12 @@ export class ColdstakeService implements OnDestroy {
   }
 
   update() {
+    this._rpcState.observe('getwalletinfo', 'encryptionstatus')
+    .pipe(takeWhile(() => !this.destroyed))
+    .subscribe(status => {
+      this.encryptionStatus = status;
+    });
+
     this._rpc.call('getcoldstakinginfo').subscribe(coldstakinginfo => {
       this.log.d('stakingStatus called ' + coldstakinginfo['enabled']);
       this.progress = new Amount(coldstakinginfo['percent_in_coldstakeable_script'], 2);

--- a/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.html
+++ b/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.html
@@ -22,7 +22,7 @@
     Cancel
   </button>
 
-  <button mat-raised-button color="warn" (click)="revert()">
+  <button mat-raised-button color="warn" (click)="revert()"  [disabled]="utxos.txs.length > 0 && !fee">
     <mat-icon fontSet="partIcon" fontIcon="part-refresh"></mat-icon>
     Disable Cold Staking
   </button>

--- a/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.ts
+++ b/src/app/wallet/overview/widgets/coldstake/revert-coldstaking/revert-coldstaking.component.ts
@@ -36,7 +36,6 @@ export class RevertColdstakingComponent implements OnInit {
       txs: [],
       amount: 0
     };
-
     this._rpc.call('liststealthaddresses', null)
       .subscribe(stealthAddresses => {
         try {
@@ -78,9 +77,9 @@ export class RevertColdstakingComponent implements OnInit {
               subfee: true,
               address: this.address,
               amount: tx.amount
-            }], '', '', 4, 64, true, JSON.stringify({
+            }], '', '', 4, 64, true,{
               inputs: tx.inputs
-            })]).subscribe(res => {
+            }]).subscribe(res => {
 
               sentTXs++;
               totalFee += res.fee;
@@ -90,13 +89,13 @@ export class RevertColdstakingComponent implements OnInit {
                 this.fee = totalFee;
               }
             }, error => {
-              this.log.er('errr');
+              this.log.er('errr',error);
             });
           });
         });
       },
         error => {
-          this.log.er('errr');
+          this.log.er('errr',error);
         });
   }
 
@@ -120,9 +119,9 @@ export class RevertColdstakingComponent implements OnInit {
         subfee: true,
         address: this.address,
         amount: tx.amount
-      }], 'revert coldstaking', '', 4, 64, false, JSON.stringify({
+      }], 'revert coldstaking', '', 4, 64, false, {
         inputs: tx.inputs
-      })]).subscribe(res => {
+      }]).subscribe(res => {
 
         this.log.d('revert response', res);
         amount += tx.amount;

--- a/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.ts
+++ b/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.ts
@@ -62,7 +62,7 @@ export class ZapColdstakingComponent {
       }
 
     }, error => {
-      this.log.er('errr');
+      this.log.er('errr', error);
     });
   }
 

--- a/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.ts
+++ b/src/app/wallet/overview/widgets/coldstake/zap-coldstaking/zap-coldstaking.component.ts
@@ -17,6 +17,8 @@ export class ZapColdstakingComponent {
   private log: any = Log.create('zap-coldstaking');
 
   public utxos: any;
+  public inputs: any;
+
   fee: number;
   script: string;
   public zapSplitDefaultAmount: Amount = new Amount(1500, 8);
@@ -38,7 +40,7 @@ export class ZapColdstakingComponent {
       txs: [],
       amount: 0
     };
-
+    this.inputs = [];
     this._rpc.call('walletsettings', ['changeaddress']).subscribe(res => {
 
       this.log.d('pkey', res);
@@ -80,9 +82,9 @@ export class ZapColdstakingComponent {
             amount: utxo.amount,
             inputs: [{ tx: utxo.txid, n: utxo.vout }]
           });
+          this.inputs.push({ tx: utxo.txid, n: utxo.vout });
         };
       });
-
       this._rpc.call('getnewaddress', ['""', 'false', 'false', 'true'])
         .subscribe(spendingAddress => {
           this.log.d('spending address', spendingAddress);
@@ -128,9 +130,8 @@ export class ZapColdstakingComponent {
 
             this.log.d('zap splits', splits);
 
-            this._rpc.call('sendtypeto', ['ghost', 'ghost', outputs, '', '', 4, 64, true, JSON.stringify({
-              inputs: this.utxos.txs
-            })]).subscribe(tx => {
+            this._rpc.call('sendtypeto', ['ghost', 'ghost', outputs, '', '', 4, 64, true, {inputs: this.inputs}
+          ]).subscribe(tx => {
               this.log.d('fees', tx);
               this.fee = tx.fee;
             });
@@ -169,9 +170,7 @@ export class ZapColdstakingComponent {
     this.log.d('zap splits', splits);
 
 
-    this._rpc.call('sendtypeto', ['ghost', 'ghost', outputs, 'coldstaking zap', '', 4, 64, false, JSON.stringify({
-      inputs: this.utxos.txs
-    })]).subscribe(info => {
+    this._rpc.call('sendtypeto', ['ghost', 'ghost', outputs, 'coldstaking zap', '', 4, 64, false, {inputs: this.inputs}]).subscribe(info => {
       this.log.d('zap', info);
 
       this.dialogRef.close();

--- a/src/app/wallet/overview/widgets/stake/stake.component.html
+++ b/src/app/wallet/overview/widgets/stake/stake.component.html
@@ -4,7 +4,7 @@
   </header>
 
   <mat-card *ngIf="_stake.stakingEnabled && !isLocked()" class="staking-node active">
-    <button mat-raised-button color="primary" (click)="lockWallet()" matTooltip="Lock wallet disable staking">
+    <button mat-raised-button color="primary" (click)="lockWallet()" matTooltip="Lock wallet to stop staking">
       <img class="filter-white" src="assets/icons/SVG/monetization-on.svg"/>
     </button>
     <div class="title">Staking</div>
@@ -12,15 +12,15 @@
   </mat-card>
 
   <mat-card *ngIf="isLocked()" class="staking-node inactive">
-    <button mat-raised-button color="primary" (click)="openUnlockWalletModal()" matTooltip="Unlock wallet to enable staking">
+    <button mat-raised-button color="primary" (click)="openUnlockWalletModal()" matTooltip="Unlock wallet to start hot staking">
       <mat-icon fontSet="partIcon" fontIcon="part-lock"></mat-icon>
     </button>
     <div class="title">Not Staking</div>
-    <div class="subtitle">Unlock to start staking</div>
+    <div class="subtitle">Unlock to start hot staking</div>
   </mat-card>
 
   <p class="widget-help" *ngIf="_stake.stakingEnabled && _stake.hotstake.amount > 0 && !isLocked()">
-    {{_stake.hotstake.amount}} of your balance is now staking. Only your public account balance can be used for staking.
+    {{_stake.hotstake.amount}} of your balance is now staking. Only your public account balance can be used for hot staking.
   </p>
 
 

--- a/src/app/wallet/overview/widgets/stake/stake.component.html
+++ b/src/app/wallet/overview/widgets/stake/stake.component.html
@@ -7,7 +7,6 @@
     <button mat-raised-button color="primary" (click)="lockWallet()" matTooltip="Lock wallet to stop staking">
       <img class="filter-white" src="assets/icons/SVG/monetization-on.svg"/>
     </button>
-    <div class="title">Staking</div>
     <div class="subtitle">Active</div>
   </mat-card>
 

--- a/src/app/wallet/overview/widgets/stake/stake.component.html
+++ b/src/app/wallet/overview/widgets/stake/stake.component.html
@@ -1,6 +1,6 @@
 <div class="staking section">
   <header>
-    <div class="subtitle">Staking</div>
+    <div class="subtitle">Hot Staking</div>
   </header>
 
   <mat-card *ngIf="_stake.stakingEnabled && !isLocked()" class="staking-node active">

--- a/src/app/wallet/overview/widgets/stake/stake.component.html
+++ b/src/app/wallet/overview/widgets/stake/stake.component.html
@@ -7,7 +7,8 @@
     <button mat-raised-button color="primary" (click)="lockWallet()" matTooltip="Lock wallet to stop staking">
       <img class="filter-white" src="assets/icons/SVG/monetization-on.svg"/>
     </button>
-    <div class="subtitle">Active</div>
+    <div class="subtitle" *ngIf="_stake.hotstake.amount > 0">Active</div>
+    <div *ngIf="_stake.hotstake.amount === 0">Enabled, but coins not mature or no coins</div>
   </mat-card>
 
   <mat-card *ngIf="isLocked()" class="staking-node inactive">

--- a/src/app/wallet/overview/widgets/stake/stake.service.ts
+++ b/src/app/wallet/overview/widgets/stake/stake.service.ts
@@ -12,7 +12,7 @@ export class StakeService implements OnDestroy {
   private destroyed: boolean = false;
   private log: any = Log.create('stake-service');
 
-  public hotstake: any = {
+  public hotstake: {txs: any[], amount: number} = {
     txs: [],
     amount: 0
   };
@@ -44,6 +44,10 @@ export class StakeService implements OnDestroy {
       .pipe(takeWhile(() => !this.destroyed))
       .subscribe(status => this.stakingEnabled = status);
 
+    this._rpcState.observe('getstakinginfo', 'weight')
+      .pipe(takeWhile(() => !this.destroyed))
+      .subscribe(weight => this.hotstake.amount = (new Amount(weight)).getGhostCoins());
+
     this.update();
   }
 
@@ -63,12 +67,18 @@ export class StakeService implements OnDestroy {
       } else {
         this.stakingEnabled = false;
       }
-
-      this.updateHotStakingInfo();
+      if ('weight' in stakinginfo) {
+        const weight = stakinginfo['weight'];
+        this.hotstake.amount = (new Amount(weight)).getGhostCoins();
+      } else {
+        this.stakingEnabled = false;
+      }
+    // TODO: Remove this later if not used
+     // this.updateHotStakingInfo();
     }, error => this.log.er('couldn\'t get stakinginfo', error));
   }
-
-  private updateHotStakingInfo() {
+  // TODO: Remove this later if not used
+ /* private updateHotStakingInfo() {
     const hotstake =  {
       txs: [],
       amount: 0
@@ -88,7 +98,7 @@ export class StakeService implements OnDestroy {
       });
       this.hotstake = hotstake;
     });
-  }
+  }*/
 
   ngOnDestroy() {
     this.destroyed = true;

--- a/src/app/wallet/wallet/shared/transaction.model.ts
+++ b/src/app/wallet/wallet/shared/transaction.model.ts
@@ -145,7 +145,7 @@ export class Transaction {
       // Transfer to himself
       if (this.type_in === 'standard' && this.type_output === 'standard') {
         if (this.outputs.length) {
-          return this.outputs.map(o => o.amount ).reduce( (c: number, p: number) =>  p + c );
+          return this.outputs.map(o => Number(o.amount) ).reduce( (c: number, p: number) =>  p + c );
         }
       }
       const blindStealthOutputCount = this.outputs.reduce(function (a: any, b: any) {


### PR DESCRIPTION
Fixes #47 
Fixes #48 
The follow was done:

- Enable back cold staking
- Rename Staking to Hot Staking
- Put Cold Staking Component on Top
- Use weight now as way to compute the amount of coins being hot staking
- Splits zap amounts for better staking efficiency
- Remove Staking column and add the amount to Immature field

Screenshot below:
![image](https://user-images.githubusercontent.com/8621730/86160327-f50e8980-bae1-11ea-8d31-dee27de227eb.png)



