### PR TITLE
show wallet ui when daemon is syncing with the network

### DIFF
--- a/src/app/loading/connection-checker.service.ts
+++ b/src/app/loading/connection-checker.service.ts
@@ -5,11 +5,17 @@ import { shareReplay } from 'rxjs/operators';
 
 import { RpcService } from 'app/core/rpc/rpc.service';
 
+enum SyncStatus {
+  SYNCING_NETWORK = 0,
+  LOADING_WALLET = 1,
+  FINSHED = 2,
+}
+
 @Injectable()
 export class ConnectionCheckerService implements OnDestroy {
 
   log: any = Log.create('connection-checker.service id:' + Math.floor((Math.random() * 1000) + 1));
-  destroyed: boolean = false;
+  status: SyncStatus = SyncStatus.SYNCING_NETWORK;
 
   checkInterval: number = 1 * 1000; // milliseconds
 
@@ -36,32 +42,54 @@ export class ConnectionCheckerService implements OnDestroy {
   }
 
   public performCheck() {
-    if (!this.destroyed) {
-      this.log.d('performing check');
-      this.log.d(`connection-checker wallet:`, this.rpc.wallet);
-      this.rpc.call('getwalletinfo', []).subscribe(
-        (getwalletinfo: any) => this.RpcHasResponded(getwalletinfo),
-        (error: any) => {
-          if (error.code === -18) {
-            this.rpc.wallet = '';
+    this.log.d('performing check');
+    switch (this.status) {
+      case SyncStatus.SYNCING_NETWORK:
+        this.log.d('connection-checker network:');
+        this.rpc.call('getblockchaininfo', []).subscribe(
+          (getblockchaininfo: any) => this.NetworkRpcHasResponded(getblockchaininfo),
+          (error: any) => {
+            this.log.d('performCheck:network on rpc (error is normal here) ', error);
           }
-          this.log.d('performCheck on rpc (error is normal here) ', error)
-        }
-      );
+        );
 
+        setTimeout(this.performCheck.bind(this), this.checkInterval);
+        break;
+      case SyncStatus.LOADING_WALLET:
+        this.log.d('connection-checker wallet:', this.rpc.wallet);
+        this.rpc.call('getwalletinfo', []).subscribe(
+          (getwalletinfo: any) => this.WalletRpcHasResponded(getwalletinfo),
+          (error: any) => {
+            if (error.code === -18) {
+              this.rpc.wallet = '';
+            }
+            this.log.d('performCheck:wallet on rpc (error is normal here) ', error);
+          }
+        );
 
-      setTimeout(this.performCheck.bind(this), this.checkInterval);
+        setTimeout(this.performCheck.bind(this), this.checkInterval);
+        break;
+      default:
+        break;
     }
   }
 
-  private RpcHasResponded(getwalletinfo: any) {
-    this.log.info('RPC is responsive, yay!');
-    this.observer.next(getwalletinfo);
+  private NetworkRpcHasResponded(getblockchaininfo: any) {
+    this.log.info('Network RPC is responsive, yay!');
+    this.observer.next({...getblockchaininfo, 'rpc_command': 'blockchaininfo'});
+    if (getblockchaininfo.blocks === getblockchaininfo.headers) {
+      this.status = SyncStatus.LOADING_WALLET;
+    }
+  }
+
+  private WalletRpcHasResponded(getwalletinfo: any) {
+    this.log.info('Wallet RPC is responsive, yay!');
+    this.observer.next({...getwalletinfo, 'rpc_command': 'walletinfo'});
     this.observer.complete();
-    this.destroyed = true;
+    this.status = SyncStatus.FINSHED;
   }
 
   ngOnDestroy() {
-    this.destroyed = true;
+    this.status = SyncStatus.FINSHED;
   }
 }

--- a/src/app/loading/loading.component.html
+++ b/src/app/loading/loading.component.html
@@ -10,6 +10,10 @@
     <span><i>{{loadingMessage}}</i></span>
   </div>
 
+  <div *ngIf="blockReceived != blockHeader">
+    <p>Syncing with the network, {{blockReceived}}/{{blockHeader}} block(s) received.</p>
+  </div>
+  
   <blockquote class="quote">
     <p>A specter is haunting the modern world, the specter of crypto anarchy.</p>
     <footer class="author">&mdash; Tim May - The Crypto Anarchy Manifesto 1992.</footer>

--- a/src/app/loading/loading.component.ts
+++ b/src/app/loading/loading.component.ts
@@ -80,7 +80,7 @@ export class LoadingComponent implements OnInit {
                       this.rpc.daemonProtocol = +networkinfo.protocolversion;
                     }
                   }).catch(rpcErr => {
-                    // do nothing, mostly just prevents an error from not being handled in case of an issue
+                    this.log.er('getnetworkinfo failed: may already be stopped: ', rpcErr);
                   });
                 }
                 this.multi.refreshWalletList();

--- a/src/app/loading/loading.component.ts
+++ b/src/app/loading/loading.component.ts
@@ -25,6 +25,9 @@ export class LoadingComponent implements OnInit {
 
   loadingMessage: string;
 
+  blockReceived: number = 0;
+  blockHeader: number = 0;
+
   constructor(
     private router: Router,
     private route: ActivatedRoute,
@@ -66,27 +69,32 @@ export class LoadingComponent implements OnInit {
         this.con
           .whenRpcIsResponding()
           .subscribe(
-            async getwalletinfo => {
-              if (!this.rpc.daemonProtocol) {
-                await this.rpc.call('getnetworkinfo').toPromise().then(networkinfo => {
-                  if (networkinfo && +networkinfo.protocolversion) {
-                    this.rpc.daemonProtocol = +networkinfo.protocolversion;
-                  }
-                }).catch(rpcErr => {
-                  // do nothing, mostly just prevents an error from not being handled in case of an issue
-                });
-              }
-              this.multi.refreshWalletList();
-              // Swap smsg to the new wallet
-              this.rpc.call('smsgdisable').subscribe(
-                () => {
-                  this.activateWallet(getwalletinfo, true);
-                },
-                (err) => {
-                  this.log.er('smsgdisable failed: may already be stopped: ', err);
-                  this.activateWallet(getwalletinfo, false);
+            async response => {
+              if (response.rpc_command === 'blockchaininfo') {
+                this.blockReceived = response.blocks;
+                this.blockHeader = response.headers;
+              } else {
+                if (!this.rpc.daemonProtocol) {
+                  await this.rpc.call('getnetworkinfo').toPromise().then(networkinfo => {
+                    if (networkinfo && +networkinfo.protocolversion) {
+                      this.rpc.daemonProtocol = +networkinfo.protocolversion;
+                    }
+                  }).catch(rpcErr => {
+                    // do nothing, mostly just prevents an error from not being handled in case of an issue
+                  });
                 }
-              );
+                this.multi.refreshWalletList();
+                // Swap smsg to the new wallet
+                this.rpc.call('smsgdisable').subscribe(
+                  () => {
+                    this.activateWallet(response, true);
+                  },
+                  (err) => {
+                    this.log.er('smsgdisable failed: may already be stopped: ', err);
+                    this.activateWallet(response, false);
+                  }
+                );
+              }
             },
             error => this.log.d('whenRpcIsResponding errored')
           );


### PR DESCRIPTION
#22  We often use the getblockchaininfo rpc command to check sync status of the daemon.
Here, the number of blocks received should be same as the headers parameter.
It shows "Syncing with the network, xxx/yyy block(s) received" message while the daemon is syncing.
![1](https://user-images.githubusercontent.com/35329373/87453787-69027300-c646-11ea-8a25-7629ec7189ca.PNG)
