### PR TITLE
not able to send an anon transaction to stealth bech32

### DIFF
--- a/src/app/core/util/util.spec.ts
+++ b/src/app/core/util/util.spec.ts
@@ -25,6 +25,13 @@ describe('AddressHelper', () => {
     expect(addressHelper.getAddress(mainAddress)).toEqual(mainAddress);
   }));
 
+  it('should test bech32 address', inject([AddressHelper], (addressHelper: AddressHelper) => {
+    const bech32Address = 'gx1qqp528m7654yhav5clp5jq83cfu6nwpl76atpqvlzn6hchk4ah7xs' +
+    'gcpqvrxkkzamn5mrw42gr97xcyna83p07zafy7p3kyx6q2qfz8k86m95qqqjtremu';
+    expect(addressHelper.testAddress(bech32Address, 'private')).toBe(true);
+    expect(addressHelper.getAddress(bech32Address)).toEqual(bech32Address);
+  }));
+
 });
 
 describe('Amount', () => {

--- a/src/app/core/util/utils.ts
+++ b/src/app/core/util/utils.ts
@@ -202,8 +202,8 @@ export class Duration {
 
 export class AddressHelper {
   addressPublicRegex: RegExp = /^[gGxX][a-km-zA-HJ-NP-Z1-9]{25,52}$/;
-  addressPrivateRegex: RegExp = /^[Ss][a-km-zA-HJ-NP-Z1-9]{60,}$/
-  addressBothRegex: RegExp = /^[gGsSxX][a-km-zA-HJ-NP-Z1-9]{25,}$/;
+  addressPrivateRegex: RegExp = /(^[Ss][a-km-zA-HJ-NP-Z1-9]{60,}$|(^[gG][a-z0-9]{120,}$))/;
+  addressBothRegex: RegExp = /^[gGsSxX][a-zA-HJ-NP-Z0-9]{25,}$/;
 
   testAddress(address: string, type?: string): boolean {
     return this[(type ? type === 'public'


### PR DESCRIPTION
This resolves #24 

AddressHelper has a module to check the receiver address using Regular Expression. The pre-defined addressPrivateRegex didn't work for the stealth bech32 address.