### PR TITLE
add legacy wallet notification

### DIFF
--- a/src/app/wallet/overview/overview.component.html
+++ b/src/app/wallet/overview/overview.component.html
@@ -67,7 +67,8 @@
 
     <div class="recent-transactions section">
       <header>
-        <div class="subtitle">Recent Transactions</div>
+        <div class="legacy-notification" *ngIf="firstTxBlock < 5955">Legacy wallet, learn how to upgrade here</div>
+        <div class="subtitle" [ngClass]="{'del-margin-top' : firstTxBlock < 5955}">Recent Transactions</div>
         <!-- TODO: uncomment when widget management is ready -->
         <!--div class="buttons">
           <mat-icon class="icon" fontSet="partIcon" fontIcon="part-cog" matTooltip="Edit widget"></mat-icon>

--- a/src/app/wallet/overview/overview.component.scss
+++ b/src/app/wallet/overview/overview.component.scss
@@ -28,6 +28,22 @@
   }
 }
 
+.legacy-notification {
+  color: darken($color-alert, 5%);
+  border-color: $color-alert;
+  margin-top: 10px;
+  text-align: center;
+}
+
+.section {
+  // override margin-top of overview section titles
+  header {
+    .del-margin-top {
+      margin-top: 0;
+    }
+  }
+}
+
 .overview { // area with widgets
   display: flex;
   padding: 0 35px 50px;

--- a/src/app/wallet/overview/overview.component.ts
+++ b/src/app/wallet/overview/overview.component.ts
@@ -1,19 +1,27 @@
 
 import { Component, OnInit } from '@angular/core';
-import { RpcStateService } from '../../core/core.module';
+import { RpcStateService, RpcService } from '../../core/core.module';
 import { MatDialog, MatDialogRef } from '@angular/material';
 
 import { ManageWidgetsComponent } from '../../modals/manage-widgets/manage-widgets.component';
 import { take } from 'rxjs/operators';
+import { TransactionService } from '../wallet/shared/transaction.service';
 
 @Component({
   selector: 'app-overview',
   templateUrl: './overview.component.html',
   styleUrls: ['./overview.component.scss'],
+  providers: [TransactionService],
 })
 export class OverviewComponent implements OnInit {
   testnet: boolean = false;
-  constructor(public dialog: MatDialog, private rpcState: RpcStateService) { }
+  timeInterval: number = 0.5 * 1000;  // 0.5 second
+  firstTxBlock: number = 5955;  // no legacy wallet
+  constructor(
+    public dialog: MatDialog,
+    public txService: TransactionService,
+    private rpcState: RpcStateService,
+    private rpc: RpcService) { }
 
   openWidgetManager(): void {
     const dialogRef = this.dialog.open(ManageWidgetsComponent);
@@ -23,6 +31,33 @@ export class OverviewComponent implements OnInit {
     // check if testnet -> Show/Hide Anon Balance
     this.rpcState.observe('getblockchaininfo', 'chain').pipe(take(1))
      .subscribe(chain => this.testnet = chain === 'test');
+    this.txService.postConstructor(1);
+    this.getTxs();
   }
 
+  private getTxs() {
+    if (!this.txService.loading) {
+      if (this.txService.txCount > 1) {
+        this.txService.changePage(this.txService.txCount - 1);
+        this.getFirstTxBlock();
+      } else if (this.txService.txCount === 1) {
+        this.getFirstTxBlock();
+      }
+      return;
+    }
+    setTimeout(this.getTxs.bind(this), this.timeInterval);
+  }
+
+  private getFirstTxBlock() {
+    if (!this.txService.loading) {
+      this.rpc.call('getblock', [this.txService.txs[0].blockhash]).subscribe(
+        (getblock: any) => this.firstTxBlock = getblock.height,
+        (error: any) => {
+          // Error Handle
+        }
+      )
+      return;
+    }
+    setTimeout(this.getFirstTxBlock.bind(this), this.timeInterval);
+  }
 }


### PR DESCRIPTION
This resolves #61 

When the wallet starts, it checks the block height of users' first transaction and if it's before #5955, it shows a notification.
![capture](https://user-images.githubusercontent.com/35329373/87690175-75183d00-c7cc-11ea-984f-e4d384100417.png)
