### PR TITLE
Update paginator.component.ts [spelling/typography]

### DIFF
--- a/src/app/core-ui/paginator/paginator.component.ts
+++ b/src/app/core-ui/paginator/paginator.component.ts
@@ -12,8 +12,8 @@ enum Intl {
   itemsPerPageLabel = 'Items per page',
   nextPageLabel = 'Next page',
   previousPageLabel = 'Previous page',
-  firstPageLable = 'Fist Page',
-  lastPageLable = 'Last Page',
+  firstPageLable = 'First page',
+  lastPageLable = 'Last page',
 }
 
 @Component({


### PR DESCRIPTION
Corrected "Fist" to "First." [typo]
Changed "Page" to "page" (2x) [internal consistency issue; cp. "Next page", "Previous page"; both use small letters in the word "page"; so let's use "page" with small letters everywhere.

Fixes #97 

'dev' seems to be so old and stale (3+ years) that I used 'ghost-2.4' as a base.

